### PR TITLE
Add Sendable conformance to generated Assets

### DIFF
--- a/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
@@ -129,7 +129,7 @@
   {% endfor %}
 {% endmacro %}
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
-{{accessModifier}} enum {{enumName}} {
+{{accessModifier}} enum {{enumName}}: Sendable {
   {% if catalogs.count > 1 or param.forceFileNameEnum %}
   {% for catalog in catalogs %}
   {{accessModifier}} enum {{catalog.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
@@ -275,7 +275,7 @@
 {% endif %}
 {% if hasImage %}
 
-{{accessModifier}} struct {{imageType}} {
+{{accessModifier}} struct {{imageType}}: Sendable {
   {{accessModifier}} fileprivate(set) var name: String
 
   #if os(macOS)


### PR DESCRIPTION
## What's done:

* added Sendable conformance to ImageAsset and Asset types so the generated code is Swift6- and strict-concurrency-checks- ready. Since all types that are used in the equation are `Sendable`, and since `Sendable` is available iOS 8+, macOS 10.10+, watchOS 2.0+ (in other words from the very old versions), it should be safe to just add Sendable conformance to the swift5 stencil without introducing breaking changes. This will allow people to use the generated codes without any unwanted warnings from the compiler.

* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [ ] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

